### PR TITLE
Add view for empty orders

### DIFF
--- a/Bottomless.xcodeproj/project.pbxproj
+++ b/Bottomless.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3A0458FC249DC8E300366F10 /* Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0458FB249DC8E300366F10 /* Encodable.swift */; };
 		3A0458FE249E11BC00366F10 /* OrderingStrategyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0458FD249E11BC00366F10 /* OrderingStrategyView.swift */; };
 		3A045900249E13DE00366F10 /* OrderingStrategyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0458FF249E13DE00366F10 /* OrderingStrategyViewModel.swift */; };
+		3A858C9624AD05B900F535D2 /* NoOrdersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A858C9524AD05B900F535D2 /* NoOrdersView.swift */; };
 		3AD926922491547E000AEFC8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD926912491547E000AEFC8 /* AppDelegate.swift */; };
 		3AD926942491547E000AEFC8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD926932491547E000AEFC8 /* SceneDelegate.swift */; };
 		3AD926962491547E000AEFC8 /* LoggedInTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD926952491547E000AEFC8 /* LoggedInTabsView.swift */; };
@@ -109,6 +110,7 @@
 		3A0458FB249DC8E300366F10 /* Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encodable.swift; sourceTree = "<group>"; };
 		3A0458FD249E11BC00366F10 /* OrderingStrategyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingStrategyView.swift; sourceTree = "<group>"; };
 		3A0458FF249E13DE00366F10 /* OrderingStrategyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingStrategyViewModel.swift; sourceTree = "<group>"; };
+		3A858C9524AD05B900F535D2 /* NoOrdersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOrdersView.swift; sourceTree = "<group>"; };
 		3AD9268E2491547E000AEFC8 /* Bottomless.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bottomless.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AD926912491547E000AEFC8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3AD926932491547E000AEFC8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -391,6 +393,7 @@
 				3AD927162497F6F9000AEFC8 /* UpNextOrder.swift */,
 				3AD926FD2496FCE4000AEFC8 /* InProgressOrder.swift */,
 				3AD927142497F629000AEFC8 /* PastOrder.swift */,
+				3A858C9524AD05B900F535D2 /* NoOrdersView.swift */,
 			);
 			path = ProfileView;
 			sourceTree = "<group>";
@@ -628,6 +631,7 @@
 				3A0458F2249C9B0400366F10 /* ImageLoader.swift in Sources */,
 				3AD9272624981A85000AEFC8 /* OrdersViewModel.swift in Sources */,
 				3A0458F4249CA37F00366F10 /* SettingsSegmentView.swift in Sources */,
+				3A858C9624AD05B900F535D2 /* NoOrdersView.swift in Sources */,
 				3AD926B124915679000AEFC8 /* Colors.swift in Sources */,
 				3A0458F02499D07200366F10 /* SearchDetailView.swift in Sources */,
 				3AD926CD2491CCE1000AEFC8 /* PasswordField.swift in Sources */,

--- a/Bottomless/Models/Orders/InTransitionResponse.swift
+++ b/Bottomless/Models/Orders/InTransitionResponse.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 struct InTransitionResultResponse: Decodable {
-    var data: [InTransitionResponse]
+    var data: [InTransitionResponse?]
 }
 
 struct InTransitionResponse: Hashable, Identifiable, Decodable {

--- a/Bottomless/Models/Orders/OrdersResponse.swift
+++ b/Bottomless/Models/Orders/OrdersResponse.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 struct OrdersResultResponse: Decodable {
-    var data: [OrdersResponse]
+    var data: [OrdersResponse?]
 }
 
 struct OrdersResponse: Hashable, Identifiable, Decodable {

--- a/Bottomless/Models/Scale/RecordsResponse.swift
+++ b/Bottomless/Models/Scale/RecordsResponse.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RecordsResultResponse: Decodable {
-    var data: [RecordsResponse]
+    var data: [RecordsResponse?]
 }
 
 struct RecordsResponse: Hashable, Identifiable, Decodable {

--- a/Bottomless/View Models/InTransitionViewModel.swift
+++ b/Bottomless/View Models/InTransitionViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import SwiftUI
 
 final class InTransitionViewModel: ObservableObject {
-    @Published private(set) var inTransitionResponse: [InTransitionResponse]? = nil
+    @Published private(set) var inTransitionResponse: [InTransitionResponse]? = []
 
     private var inTransitionCancellable: Cancellable? {
         didSet { oldValue?.cancel() }
@@ -24,7 +24,7 @@ final class InTransitionViewModel: ObservableObject {
         inTransitionCancellable = publisher
             .map { $0.data }
             .decode(type: InTransitionResultResponse.self, decoder: JSONDecoder())
-            .map { $0.data }
+            .map { $0.data as? [InTransitionResponse] }
             .replaceError(with: nil)
             .receive(on: RunLoop.main)
             .assign(to: \.inTransitionResponse, on: self)

--- a/Bottomless/View Models/OrdersViewModel.swift
+++ b/Bottomless/View Models/OrdersViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import SwiftUI
 
 final class OrdersViewModel: ObservableObject {
-    @Published private(set) var ordersResponse: [OrdersResponse]? = nil
+    @Published private(set) var ordersResponse: [OrdersResponse]? = []
 
     private var ordersCancellable: Cancellable? {
         didSet { oldValue?.cancel() }
@@ -24,7 +24,7 @@ final class OrdersViewModel: ObservableObject {
         ordersCancellable = publisher
             .map { $0.data }
             .decode(type: OrdersResultResponse.self, decoder: JSONDecoder())
-            .map { $0.data }
+            .map { $0.data as? [OrdersResponse] }
             .replaceError(with: nil)
             .receive(on: RunLoop.main)
             .assign(to: \.ordersResponse, on: self)

--- a/Bottomless/View Models/RecordsViewModel.swift
+++ b/Bottomless/View Models/RecordsViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import SwiftUI
 
 final class RecordsViewModel: ObservableObject {
-    @Published private(set) var recordsResponse: [RecordsResponse]?
+    @Published private(set) var recordsResponse: [RecordsResponse]? = []
 
     private var recordsCancellable: Cancellable? {
         didSet { oldValue?.cancel() }
@@ -24,7 +24,7 @@ final class RecordsViewModel: ObservableObject {
         recordsCancellable = publisher
             .map { $0.data }
             .decode(type: RecordsResultResponse.self, decoder: JSONDecoder())
-            .map { $0.data }
+            .map { $0.data as? [RecordsResponse] }
             .replaceError(with: nil)
             .receive(on: RunLoop.main)
             .assign(to: \.recordsResponse, on: self)

--- a/Bottomless/Views/LoggedInTabs/ProfileView/NoOrdersView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/NoOrdersView.swift
@@ -1,0 +1,36 @@
+//
+//  NoOrdersView.swift
+//  Bottomless
+//
+//  Created by Drew Volz on 7/1/20.
+//  Copyright © 2020 Drew Volz. All rights reserved.
+//
+
+import SwiftUI
+
+struct NoOrders: View {
+    @State var message: String
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(verbatim: message)
+                .font(.body)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+        }
+    }
+}
+
+struct NoOrders_Previews: PreviewProvider {
+    static var previews: some View {
+        List {
+            Group {
+                Section {
+                    NoOrders(message: "No orders")
+                }
+            }
+        }
+        .listStyle(GroupedListStyle())
+        .environment(\.horizontalSizeClass, .regular)
+    }
+}

--- a/Bottomless/Views/LoggedInTabs/ProfileView/OrdersView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/OrdersView.swift
@@ -9,25 +9,31 @@ struct OrdersView: View {
         Group {
             List {
                 Group {
-                    if hasUpNextOrder(order: upNextViewModel.upNextResponse) {
-                        Section(header: Text("Up Next").font(.subheadline)) {
+                    Section(header: Text("Up Next").font(.subheadline)) {
+                        if hasUpNextOrder(order: upNextViewModel.upNextResponse) {
                             UpNextOrder(order: upNextViewModel.upNextResponse!)
+                        } else {
+                            NoOrders(message: "No upcoming orders")
                         }
                     }
 
-                    if hasInTransitionOrders(orders: inTransitionViewModel.inTransitionResponse) {
-                        Section(header: Text("Orders In Progress").font(.subheadline)) {
-                            ForEach(inTransitionViewModel.inTransitionResponse ?? []) { order in
+                    Section(header: Text("Orders In Progress").font(.subheadline)) {
+                        if hasInTransitionOrders(orders: inTransitionViewModel.inTransitionResponse) {
+                            ForEach(inTransitionViewModel.inTransitionResponse!) { order in
                                 InProgressOrder(order: order)
                             }
+                        } else {
+                            NoOrders(message: "No orders in progress")
                         }
                     }
 
-                    if hasPastOrders(orders: pastOrdersViewModel.ordersResponse) {
-                        Section(header: Text("Past Orders").font(.subheadline)) {
-                            ForEach(pastOrdersViewModel.ordersResponse ?? []) { order in
+                    Section(header: Text("Past Orders").font(.subheadline)) {
+                        if hasPastOrders(orders: pastOrdersViewModel.ordersResponse) {
+                            ForEach(pastOrdersViewModel.ordersResponse!) { order in
                                 PastOrder(order: order)
                             }
+                        } else {
+                            NoOrders(message: "No past orders")
                         }
                     }
                 }
@@ -45,11 +51,11 @@ struct OrdersView: View {
     }
 
     private func hasInTransitionOrders(orders: [InTransitionResponse]?) -> Bool {
-        return Array(arrayLiteral: orders).count > 0
+        return orders!.count > 0
     }
 
     private func hasPastOrders(orders: [OrdersResponse]?) -> Bool {
-        return Array(arrayLiteral: orders).count > 0
+        return orders!.count > 0
     }
 
     private func hasUpNextOrder(order: UpNextResponse?) -> Bool {


### PR DESCRIPTION
* Handle JSON decoding errors by presenting an empty view
* Change result type on upcoming, in-progress, and past orders
* Stop wrapping result arrays in arrays to count the elements correctly