### PR TITLE
List modifiers

### DIFF
--- a/Bottomless.xcodeproj/project.pbxproj
+++ b/Bottomless.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		3A045900249E13DE00366F10 /* OrderingStrategyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0458FF249E13DE00366F10 /* OrderingStrategyViewModel.swift */; };
 		3A46478A24AD1CE500B9D4B5 /* ScaleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46478924AD1CE500B9D4B5 /* ScaleView.swift */; };
 		3A6A950224C131330053DF8C /* SwiftUICharts in Frameworks */ = {isa = PBXBuildFile; productRef = 3A6A950124C131330053DF8C /* SwiftUICharts */; };
+		3A6A950424C13F410053DF8C /* ListModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6A950324C13F410053DF8C /* ListModifiers.swift */; };
 		3A858C9624AD05B900F535D2 /* NoOrdersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A858C9524AD05B900F535D2 /* NoOrdersView.swift */; };
 		3AD926922491547E000AEFC8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD926912491547E000AEFC8 /* AppDelegate.swift */; };
 		3AD926942491547E000AEFC8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD926932491547E000AEFC8 /* SceneDelegate.swift */; };
@@ -112,6 +113,7 @@
 		3A0458FD249E11BC00366F10 /* OrderingStrategyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingStrategyView.swift; sourceTree = "<group>"; };
 		3A0458FF249E13DE00366F10 /* OrderingStrategyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingStrategyViewModel.swift; sourceTree = "<group>"; };
 		3A46478924AD1CE500B9D4B5 /* ScaleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaleView.swift; sourceTree = "<group>"; };
+		3A6A950324C13F410053DF8C /* ListModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListModifiers.swift; sourceTree = "<group>"; };
 		3A858C9524AD05B900F535D2 /* NoOrdersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOrdersView.swift; sourceTree = "<group>"; };
 		3AD9268E2491547E000AEFC8 /* Bottomless.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bottomless.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AD926912491547E000AEFC8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 				3AD926E62493357C000AEFC8 /* Keyboard */,
 				3AD926AE24915649000AEFC8 /* ButtonViews.swift */,
 				3AD926AC24915621000AEFC8 /* TextModifiers.swift */,
+				3A6A950324C13F410053DF8C /* ListModifiers.swift */,
 				3AD926E724935419000AEFC8 /* SharedTextField.swift */,
 				3AD926CC2491CCE1000AEFC8 /* PasswordField.swift */,
 				3A0458DC2499780100366F10 /* ShareSheet.swift */,
@@ -629,6 +632,7 @@
 				3AD9272D24985DF7000AEFC8 /* RecordsResponse.swift in Sources */,
 				3AD926BA24915774000AEFC8 /* Store.swift in Sources */,
 				3AD926D924932904000AEFC8 /* AuthKeys.swift in Sources */,
+				3A6A950424C13F410053DF8C /* ListModifiers.swift in Sources */,
 				3A0458F6249CA3B100366F10 /* AccountView.swift in Sources */,
 				3AD926F124942C4A000AEFC8 /* OrdersView.swift in Sources */,
 				3AD926F324942D0B000AEFC8 /* DataView.swift in Sources */,

--- a/Bottomless/Common/ListModifiers.swift
+++ b/Bottomless/Common/ListModifiers.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+@available(iOS 14.0, *)
+struct InsetGroupedViewModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .listStyle(InsetGroupedListStyle())
+    }
+}
+
+struct GroupedViewModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .listStyle(GroupedListStyle())
+            .environment(\.horizontalSizeClass, .regular)
+    }
+}
+
+extension List {
+    func safeGroupedStyle() -> some View {
+        guard #available(iOS 14, *) else {
+            return AnyView(modifier(GroupedViewModifier()))
+        }
+
+        return AnyView(modifier(InsetGroupedViewModifier()))
+    }
+}

--- a/Bottomless/Views/LoggedInTabs/Account/AccountSegmentView.swift
+++ b/Bottomless/Views/LoggedInTabs/Account/AccountSegmentView.swift
@@ -106,8 +106,7 @@ struct AccountSegmentView: View {
                     }
                 }
             }
-            .listStyle(GroupedListStyle())
-            .environment(\.horizontalSizeClass, .regular)
+            .safeGroupedStyle()
         }
     }
 

--- a/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
+++ b/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
@@ -27,8 +27,7 @@ struct DataView: View {
                     .frame(height: 260)
                 }
             }
-            .listStyle(GroupedListStyle())
-            .environment(\.horizontalSizeClass, .regular)
+            .safeGroupedStyle()
         }
         .onAppear(perform: fetch)
     }

--- a/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
+++ b/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
@@ -20,11 +20,9 @@ struct DataView: View {
                     }
 
                     Section {
-                        LineView(data: weights?.reversed() ?? [], title: "")
-                            .padding(.top, -25)
+                        LineView(data: weights?.reversed() ?? [], title: "Scale readings")
                     }
-                    .padding(.top, -40)
-                    .frame(height: 260)
+                    .frame(height: 360)
                 }
             }
             .safeGroupedStyle()

--- a/Bottomless/Views/LoggedInTabs/Free Bag/FreeBag.swift
+++ b/Bottomless/Views/LoggedInTabs/Free Bag/FreeBag.swift
@@ -64,8 +64,7 @@ struct FreeBagView: View {
                     }
                 }
             }
-            .listStyle(GroupedListStyle())
-            .environment(\.horizontalSizeClass, .regular)
+            .safeGroupedStyle()
         }
         .onAppear(perform: fetch)
     }

--- a/Bottomless/Views/LoggedInTabs/ProfileView/OrdersView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/OrdersView.swift
@@ -38,8 +38,7 @@ struct OrdersView: View {
                     }
                 }
             }
-            .listStyle(GroupedListStyle())
-            .environment(\.horizontalSizeClass, .regular)
+            .safeGroupedStyle()
         }
         .onAppear(perform: fetch)
     }

--- a/Bottomless/Views/LoggedInTabs/SearchView/SearchDetailView.swift
+++ b/Bottomless/Views/LoggedInTabs/SearchView/SearchDetailView.swift
@@ -53,8 +53,7 @@ struct SearchDetailView: View {
                     }
                 }
             }
-            .listStyle(GroupedListStyle())
-            .environment(\.horizontalSizeClass, .regular)
+            .safeGroupedStyle()
         }
     }
 }


### PR DESCRIPTION
__Base branch is `revert-chart`. Merge this branch into there before merging `revert-chart`.__

Introduces `.safeGroupedStyle()` modifier.
  * Wraps inset-grouped vs grouped list styles.
  * Respects iOS availability of 14.0 for InsetGrouped
  * Fallback on Grouped with regular horizontal size class

Misc
  * Tweaks the frame of the lineview