### PR TITLE
Add init method instead of onAppear for App config

### DIFF
--- a/Bottomless/App.swift
+++ b/Bottomless/App.swift
@@ -13,16 +13,19 @@ struct Bottomless: App {
     @StateObject private var store = Store()
     @StateObject private var authManager = AuthenticationManager()
 
+    init() {
+        configure()
+    }
+
     @SceneBuilder var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(authManager)
                 .environmentObject(store)
-                .onAppear(perform: initialLaunch)
         }
     }
 
-    private func initialLaunch() {
+    private func configure() {
         if !UserDefaults.standard.bool(forKey: AuthKeys.initialLaunchKey) {
             authManager.deleteAccount()
             UserDefaults.standard.set(true, forKey: AuthKeys.initialLaunchKey)


### PR DESCRIPTION
Opt for using the default `init` method instead of `onApepar`. Timing is important.