### PR TITLE
Change name of app struct to fix preview target name collision

### DIFF
--- a/Bottomless/App.swift
+++ b/Bottomless/App.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 @main
-struct Bottomless: App {
+struct BottomlessApp: App {
     @StateObject private var store = Store()
     @StateObject private var authManager = AuthenticationManager()
 


### PR DESCRIPTION
When trying to preview a swiftui struct that's a member of the
bottomless target, we'd see an error saying that the file was
not a member of `Bottomless` which is both the app's target
name and the name of the overall App struct. This change aims
to fix the preview conflating what seems to be a reserved name
for the target.