### PR TITLE
Hydrate alert settings

### DIFF
--- a/Bottomless/Views/LoggedInTabs/Account/Preferences/AlertsView.swift
+++ b/Bottomless/Views/LoggedInTabs/Account/Preferences/AlertsView.swift
@@ -27,6 +27,7 @@ struct AlertsView: View {
 
     init(accountViewModel: AccountViewModel) {
         self.accountViewModel = accountViewModel
+        alertSettings = initialAlertSettings
     }
 
     var body: some View {

--- a/Bottomless/Views/LoggedInTabs/Account/Preferences/SettingsSegmentView.swift
+++ b/Bottomless/Views/LoggedInTabs/Account/Preferences/SettingsSegmentView.swift
@@ -15,7 +15,8 @@ struct SettingsSegmentView: View {
                         AutomaticOrderingView(accountViewModel: accountViewModel)
                     }
 
-                    Section(header: Text("Alerts")) {
+                    Section(header: Text("Alerts"),
+                            footer: Text("⚠️ The app currently is not checking if you've linked a phone number to your account, so this may not be working if you select \"Text\".")) {
                         AlertsView(accountViewModel: accountViewModel)
                     }
                 }


### PR DESCRIPTION
I'm not sure how this disappeared but the initial hydration for the alerts payload was removed. This adds it (back) so that whenever a preference is tweaked, we have the latest copy of the preferences to send to the server.

In addition to #12, I'm making it more clear in UI that text alerts are not exactly supported at the moment if your phone number is not setup prior to using the app.