### PR TITLE
Encode url strings to prevent URL instances from sneezing

### DIFF
--- a/Bottomless/Models/ImageLoader.swift
+++ b/Bottomless/Models/ImageLoader.swift
@@ -56,8 +56,10 @@ class UrlImageModel: ObservableObject {
             return
         }
 
-        let url = URL(string: urlString)!
-        let task = URLSession.shared.dataTask(with: url, completionHandler: getImageFromResponse(data:response:error:))
+        let encodedUrlString = urlString.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed)!
+        let url = URL(string: encodedUrlString)
+
+        let task = URLSession.shared.dataTask(with: url!, completionHandler: getImageFromResponse(data:response:error:))
         task.resume()
     }
 


### PR DESCRIPTION
The search tab was crashing since we were forcefully coercing a value
out of the URL constructor. An illegally constructed image url would
throw an error and crash the view. This was caused by a space in the
url for the new coffees in the Stay Golden Coffee Co offerings.

The products with urls "/Stay Golden/" contain a space in their url
which we were not handling. The solution to this is to percent encode
via "urlQueryAllowed characterset" before initializing the URL instance.