### PR TITLE
Overhaul search result filtering

### DIFF
--- a/Bottomless/View Models/SearchViewModel.swift
+++ b/Bottomless/View Models/SearchViewModel.swift
@@ -4,9 +4,6 @@ import SwiftUI
 final class SearchViewModel: ObservableObject {
     @Published var query = ""
     @Published private(set) var products: [ProductResponse]? = nil
-    @Published private(set) var pristineData: [ProductResponse]? = nil
-
-    private var isFirstSearch = true
 
     private var searchCancellable: Cancellable? {
         didSet { oldValue?.cancel() }
@@ -16,23 +13,12 @@ final class SearchViewModel: ObservableObject {
         searchCancellable?.cancel()
     }
 
-    func search() {
-        if isFirstSearch {
-            pristineData = products
-            isFirstSearch.toggle()
-        }
-
-        guard !query.isEmpty else {
-            return products = pristineData
-        }
-
-        products = pristineData?
-            .filter {
-                $0.name?.lowercased().contains(query.lowercased()) ?? false ||
-                    $0.vendorName?.lowercased().contains(query.lowercased()) ?? false ||
-                    $0.roast?.name?.lowercased().contains(query.lowercased()) ?? false ||
-                    $0.origin?.name?.lowercased().contains(query.lowercased()) ?? false
-            }
+    func search(product: ProductResponse) -> Bool {
+        return query.isEmpty ||
+            product.name?.lowercased().contains(query.lowercased()) ?? false ||
+            product.vendorName?.lowercased().contains(query.lowercased()) ?? false ||
+            product.roast?.name?.lowercased().contains(query.lowercased()) ?? false ||
+            product.origin?.name?.lowercased().contains(query.lowercased()) ?? false
     }
 
     func loadData() {

--- a/Bottomless/Views/LoggedInTabs/SearchView/SearchView.swift
+++ b/Bottomless/Views/LoggedInTabs/SearchView/SearchView.swift
@@ -20,13 +20,15 @@ struct SearchView: View {
 private extension SearchView {
     @ViewBuilder func SearchBarView() -> some View {
         SearchBar(text: $searchViewModel.query,
-                  action: { self.searchViewModel.search() },
+                  action: {},
                   placeholder: "Search")
             .disableAutocorrection(true)
     }
 
     @ViewBuilder func ListView() -> some View {
-        List(searchViewModel.products ?? []) { product in
+        List(searchViewModel.products?.filter { product in
+            searchViewModel.search(product: product)
+        } ?? []) { product in
             NavigationLink(destination: SearchDetailView(
                 searchViewModel: self.searchViewModel,
                 product: product


### PR DESCRIPTION
* Filter results live instead of waiting for return
* Remove duplicate copy of product results in memory
* Handle empty-case in filter instead of toggling between datasets