### PR TITLE
Zero-pad day value in string-to-date creation

### DIFF
--- a/Bottomless/Common/DateHelpers.swift
+++ b/Bottomless/Common/DateHelpers.swift
@@ -71,7 +71,7 @@ func formatAsLongDate(dateString: String) -> String {
     formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 
     let shortFormatter = DateFormatter()
-    shortFormatter.dateFormat = "MMMM d, YYYY"
+    shortFormatter.dateFormat = "MMMM dd, YYYY"
 
     let firstDateTime = formatter.date(from: dateString) ?? Date()
 


### PR DESCRIPTION
This fixes dates sorting incorrectly in the order detail view and now shows the transit history in the correct order.