### PR TITLE
Normalize times away from military to be am/pm

### DIFF
--- a/Bottomless/Common/DateHelpers.swift
+++ b/Bottomless/Common/DateHelpers.swift
@@ -90,5 +90,17 @@ func formatAsTime(string: String) -> String {
     let hour: String = String(components.hour ?? 0)
     let minute: String = String(components.minute!).count == 1 ? "0\(components.minute ?? 0)" : String(components.minute ?? 0)
 
-    return "\(hour):\(minute)"
+    return "\(hour):\(minute)".normalizeTime()
+}
+
+extension String {
+    func normalizeTime() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HH:mm"
+
+        let date = dateFormatter.date(from: self)
+
+        dateFormatter.dateFormat = "h:mm a"
+        return dateFormatter.string(from: date!)
+    }
 }

--- a/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
@@ -50,7 +50,7 @@ private extension InTransitionDetailView {
                         HStack {
                             Text(formatAsTime(string: item.datetime))
                                 .font(.caption)
-                                .frame(width: 40)
+                                .frame(width: 60)
 
                             Text(item.message)
                                 .font(.caption)

--- a/Bottomless/Views/LoggedInTabs/ProfileView/OrderDetailView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/OrderDetailView.swift
@@ -50,7 +50,7 @@ private extension OrderDetailView {
                         HStack {
                             Text(formatAsTime(string: item.datetime))
                                 .font(.caption)
-                                .frame(width: 40)
+                                .frame(width: 60)
 
                             Text(item.message)
                                 .font(.caption)


### PR DESCRIPTION
Convert military times to AM/PM. This is used in the transit view.