### PR TITLE
Upgrade chart dependency

### DIFF
--- a/Bottomless.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bottomless.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mecid/SwiftUICharts.git",
         "state": {
           "branch": null,
-          "revision": "710dcd93d6ba9997ae360f9b6f33ebb223f42595",
-          "version": "0.3.1"
+          "revision": "6cacb77e8d3e0a9ed1d09ce9a19ba057c95ce529",
+          "version": "0.5.2"
         }
       }
     ]

--- a/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
+++ b/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
@@ -46,7 +46,7 @@ struct DataView: View {
                     }
 
                     Section(header: Text("Weight")) {
-                        BarChartView(dataPoints: weights ?? [], showLegends: false)
+                        BarChartView(dataPoints: weights ?? [])
                     }
                 }
             }

--- a/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
+++ b/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
@@ -25,6 +25,16 @@ struct DataView: View {
         }
     }
 
+    private func countLabels(for dataPoints: [DataPoint]?) -> Int {
+        var labelCount = 0
+
+        if let count = dataPoints?.count {
+            labelCount = count >= 3 ? 3 : count
+        }
+
+        return labelCount
+    }
+
     var weights: [DataPoint]? {
         recordsViewModel.recordsResponse?.reversed().compactMap { record in
             let relativeTime = formatAsRelativeTime(string: record.timestamp)
@@ -51,6 +61,7 @@ struct DataView: View {
                                 BarChartStyle(
                                     showAxis: true,
                                     showLabels: true,
+                                    labelCount: countLabels(for: weights),
                                     showLegends: false
                                 )
                             )

--- a/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
+++ b/Bottomless/Views/LoggedInTabs/DataView/DataView.swift
@@ -47,6 +47,13 @@ struct DataView: View {
 
                     Section(header: Text("Weight")) {
                         BarChartView(dataPoints: weights ?? [])
+                            .chartStyle(
+                                BarChartStyle(
+                                    showAxis: true,
+                                    showLabels: true,
+                                    showLegends: false
+                                )
+                            )
                     }
                 }
             }


### PR DESCRIPTION
* Upgrade charts dep to v0.5.2
* Remove prop from usage of barchart view (upgraded API)
* Init the chart style with:
  * visible axis and labels
  * hidden legends
* Required to show at least 1 label, so we'll max the count at 3