### PR TITLE
Adopt protocols for network requests

### DIFF
--- a/Bottomless.xcodeproj/project.pbxproj
+++ b/Bottomless.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		3A46478A24AD1CE500B9D4B5 /* ScaleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46478924AD1CE500B9D4B5 /* ScaleView.swift */; };
 		3A6A950424C13F410053DF8C /* ListModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6A950324C13F410053DF8C /* ListModifiers.swift */; };
 		3A6A97DA252E63240071DBB9 /* SwiftUICharts in Frameworks */ = {isa = PBXBuildFile; productRef = 3A6A97D9252E63240071DBB9 /* SwiftUICharts */; };
+		3A6B657A259BF2FC00C2A499 /* Fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6B6579259BF2FC00C2A499 /* Fetch.swift */; };
+		3A6B657D259BF30C00C2A499 /* FetchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6B657C259BF30C00C2A499 /* FetchProvider.swift */; };
 		3A73055B24D36DC700E71882 /* AutomaticOrderingToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A73055A24D36DC700E71882 /* AutomaticOrderingToggle.swift */; };
 		3A858C9624AD05B900F535D2 /* NoOrdersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A858C9524AD05B900F535D2 /* NoOrdersView.swift */; };
 		3AAADFC925931F2A003A0A09 /* CleanDataResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAADFC825931F2A003A0A09 /* CleanDataResponse.swift */; };
@@ -125,6 +127,8 @@
 		3A1C333624C20E9300411A5E /* info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = info.plist; path = ../info.plist; sourceTree = "<group>"; };
 		3A46478924AD1CE500B9D4B5 /* ScaleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaleView.swift; sourceTree = "<group>"; };
 		3A6A950324C13F410053DF8C /* ListModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListModifiers.swift; sourceTree = "<group>"; };
+		3A6B6579259BF2FC00C2A499 /* Fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fetch.swift; sourceTree = "<group>"; };
+		3A6B657C259BF30C00C2A499 /* FetchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProvider.swift; sourceTree = "<group>"; };
 		3A73055A24D36DC700E71882 /* AutomaticOrderingToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticOrderingToggle.swift; sourceTree = "<group>"; };
 		3A858C9524AD05B900F535D2 /* NoOrdersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOrdersView.swift; sourceTree = "<group>"; };
 		3AAADFC825931F2A003A0A09 /* CleanDataResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanDataResponse.swift; sourceTree = "<group>"; };
@@ -222,6 +226,15 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3A6B6578259BF2EA00C2A499 /* Fetch */ = {
+			isa = PBXGroup;
+			children = (
+				3A6B657C259BF30C00C2A499 /* FetchProvider.swift */,
+				3A6B6579259BF2FC00C2A499 /* Fetch.swift */,
+			);
+			path = Fetch;
 			sourceTree = "<group>";
 		};
 		3AD926852491547D000AEFC8 = {
@@ -346,6 +359,7 @@
 				3AF296B9249EDEA6004BADE8 /* PauseAccountViewModel.swift */,
 				3A0458F9249D634400366F10 /* AlertsViewModel.swift */,
 				3A0458E62499C24E00366F10 /* SearchViewModel.swift */,
+				3A6B6578259BF2EA00C2A499 /* Fetch */,
 			);
 			path = "View Models";
 			sourceTree = "<group>";
@@ -672,7 +686,9 @@
 				3A0458D624996F2400366F10 /* AccountResponse.swift in Sources */,
 				3AD926FA24943500000AEFC8 /* InTransitionResponse.swift in Sources */,
 				3AD926DD24932998000AEFC8 /* FormValidation.swift in Sources */,
+				3A6B657A259BF2FC00C2A499 /* Fetch.swift in Sources */,
 				3AD926FE2496FCE4000AEFC8 /* InProgressOrder.swift in Sources */,
+				3A6B657D259BF30C00C2A499 /* FetchProvider.swift in Sources */,
 				3A0458E72499C24E00366F10 /* SearchViewModel.swift in Sources */,
 				3A1C332F24C20ACA00411A5E /* App.swift in Sources */,
 				3AD927152497F629000AEFC8 /* PastOrder.swift in Sources */,

--- a/Bottomless/Models/AccountResponse.swift
+++ b/Bottomless/Models/AccountResponse.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct AccountResponse: Hashable, Identifiable, Decodable {
+public struct AccountResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id = "_id"
         case local
@@ -22,7 +22,7 @@ struct AccountResponse: Hashable, Identifiable, Decodable {
         case pausedUntil
     }
 
-    var id: String?
+    public var id: String?
     var local: Local?
     var alertSettings: AlertSettings?
     var firstName, lastName: String?
@@ -40,7 +40,7 @@ struct AccountResponse: Hashable, Identifiable, Decodable {
     var paused: Bool?
     var pausedUntil: String?
 
-    struct AlertSettings: Codable, Hashable {
+    public struct AlertSettings: Codable, Hashable {
         var gifs: Bool?
         var orderingSoon, outForDelivery, onTheWay, arrived: String?
         var scaleNotifications: String?
@@ -55,15 +55,15 @@ struct AccountResponse: Hashable, Identifiable, Decodable {
         }
     }
 
-    struct Local: Decodable, Hashable {
+    struct Local: Decodable, Hashable, Encodable {
         var email: String?
     }
 
-    struct VerifiedAddress: Decodable, Hashable {
+    struct VerifiedAddress: Decodable, Hashable, Encodable {
         var street1, street2, city, zip, state: String?
     }
 
-    struct PricingRule: Decodable, Hashable {
+    struct PricingRule: Decodable, Hashable, Encodable {
         var id: String?
         var freeShipping: Bool?
         var monthlyFee: Int?

--- a/Bottomless/Models/CleanDataResponse.swift
+++ b/Bottomless/Models/CleanDataResponse.swift
@@ -8,16 +8,16 @@
 
 import SwiftUI
 
-struct CleanDataResponse: Hashable, Identifiable, Decodable {
+public struct CleanDataResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case data
     }
 
-    struct CleanData: Decodable, Hashable {
+    struct CleanData: Encodable, Decodable, Hashable {
         var adjusted_weight: [String: Double?]
         var diff: [String: Double]
     }
 
-    var id = UUID()
+    public var id = UUID()
     var data: CleanData
 }

--- a/Bottomless/Models/CreditsResponse.swift
+++ b/Bottomless/Models/CreditsResponse.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
-struct CreditsResponse: Hashable, Identifiable, Decodable {
+public struct CreditsResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id = "total"
         case redeemed
         case granted
     }
 
-    var id: Int?
+    public var id: Int?
     var redeemed: Int?
     var granted: Int?
 }

--- a/Bottomless/Models/InTransitionResponse.swift
+++ b/Bottomless/Models/InTransitionResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 import SwiftUI
 
-struct InTransitionResultResponse: Decodable {
+public struct InTransitionResultResponse: Encodable, Decodable {
     var data: [InTransitionResponse?]
 }
 
-struct InTransitionResponse: Hashable, Identifiable, Decodable {
+public struct InTransitionResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id = "_id"
         case subproductID = "subproduct_id"
@@ -18,37 +18,37 @@ struct InTransitionResponse: Hashable, Identifiable, Decodable {
         case trackingUpdates = "tracking_updates"
     }
 
-    struct Grind: Decodable, Hashable {
+    struct Grind: Encodable, Decodable, Hashable {
         var _id, name: String
     }
 
-    struct OriginalProductID: Decodable, Hashable {
+    struct OriginalProductID: Encodable, Decodable, Hashable {
         var product, variant: String
     }
 
-    struct ProductID: Decodable, Hashable {
+    struct ProductID: Encodable, Decodable, Hashable {
         var product: Product
         var variant: String
     }
 
-    struct Product: Decodable, Hashable {
+    struct Product: Encodable, Decodable, Hashable {
         var _id: String
         var name: String
         var vendor_name: String
         var small_image_src: String
     }
 
-    struct VendorID: Decodable, Hashable {
+    struct VendorID: Encodable, Decodable, Hashable {
         var _id: String
         var name: String
     }
 
-    enum Status: String, Decodable, Hashable {
+    enum Status: String, Encodable, Decodable, Hashable {
         case inTransit = "in_transit"
         case preTransit = "pre_transit"
     }
 
-    struct TrackingUpdate: Decodable, Hashable {
+    struct TrackingUpdate: Encodable, Decodable, Hashable {
         enum CodingKeys: String, CodingKey {
             case trackingDetails = "tracking_details"
             case publicUrl = "public_url"
@@ -58,7 +58,7 @@ struct InTransitionResponse: Hashable, Identifiable, Decodable {
         var publicUrl: String?
     }
 
-    struct TrackingDetail: Decodable, Hashable {
+    struct TrackingDetail: Encodable, Decodable, Hashable {
         enum CodingKeys: String, CodingKey {
             case trackingLocation = "tracking_location"
             case message
@@ -70,12 +70,12 @@ struct InTransitionResponse: Hashable, Identifiable, Decodable {
         var datetime: String
     }
 
-    struct TrackingLocation: Decodable, Hashable {
+    struct TrackingLocation: Encodable, Decodable, Hashable {
         var city: String
         var state: String
     }
 
-    var id: String
+    public var id: String
     var subproductID: ProductID?
     var productID: ProductID?
     var originalProductID: OriginalProductID

--- a/Bottomless/Models/OrdersResponse.swift
+++ b/Bottomless/Models/OrdersResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 import SwiftUI
 
-struct OrdersResultResponse: Decodable {
+public struct OrdersResultResponse: Encodable, Decodable {
     var data: [OrdersResponse?]
 }
 
-struct OrdersResponse: Hashable, Identifiable, Decodable {
+public struct OrdersResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id = "_id"
         case productID = "product_id"
@@ -14,27 +14,27 @@ struct OrdersResponse: Hashable, Identifiable, Decodable {
         case trackingUpdates = "tracking_updates"
     }
 
-    struct Grind: Decodable, Hashable {
+    struct Grind: Encodable, Decodable, Hashable {
         var _id, name: String
     }
 
-    struct OriginalProductIDClass: Decodable, Hashable {
+    struct OriginalProductIDClass: Encodable, Decodable, Hashable {
         var product: String
         var variant: String
     }
 
-    struct OrderedProductIDClass: Decodable, Hashable {
+    struct OrderedProductIDClass: Encodable, Decodable, Hashable {
         var product: Product
         var variant: String
     }
 
-    struct Product: Decodable, Hashable {
+    struct Product: Encodable, Decodable, Hashable {
         var _id, name: String
         var small_image_src: String
         var vendor_name: String
     }
 
-    struct TrackingUpdate: Decodable, Hashable {
+    struct TrackingUpdate: Encodable, Decodable, Hashable {
         enum CodingKeys: String, CodingKey {
             case trackingDetails = "tracking_details"
             case publicUrl = "public_url"
@@ -44,7 +44,7 @@ struct OrdersResponse: Hashable, Identifiable, Decodable {
         var publicUrl: String?
     }
 
-    struct TrackingDetail: Decodable, Hashable {
+    struct TrackingDetail: Encodable, Decodable, Hashable {
         enum CodingKeys: String, CodingKey {
             case trackingLocation = "tracking_location"
             case message
@@ -56,12 +56,12 @@ struct OrdersResponse: Hashable, Identifiable, Decodable {
         var datetime: String
     }
 
-    struct TrackingLocation: Decodable, Hashable {
+    struct TrackingLocation: Encodable, Decodable, Hashable {
         var city: String
         var state: String
     }
 
-    var id: String
+    public var id: String
     var productID: OriginalProductIDClass
     var subproductID: OrderedProductIDClass
     var grind: Grind

--- a/Bottomless/Models/ProductResponse.swift
+++ b/Bottomless/Models/ProductResponse.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
-struct ProductResultResponse: Decodable {
+public struct ProductResultResponse: Encodable, Decodable {
     var data: [ProductResponse]
 }
 
-struct ProductResponse: Hashable, Identifiable, Decodable {
+public struct ProductResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id = "_id"
         case name
@@ -21,7 +21,7 @@ struct ProductResponse: Hashable, Identifiable, Decodable {
         case variants
     }
 
-    var id: String?
+    public var id: String?
     var name: String?
     var vendorName: String?
     var vendorId: VendorId?
@@ -35,19 +35,19 @@ struct ProductResponse: Hashable, Identifiable, Decodable {
     var tastingNotes: [TastingNote]?
     var variants: [Variant]?
 
-    struct VendorId: Decodable, Hashable {
+    struct VendorId: Decodable, Encodable, Hashable {
         var likes: Int?
     }
 
-    struct Origin: Decodable, Hashable {
+    struct Origin: Decodable, Encodable, Hashable {
         var name: String?
     }
 
-    struct Roast: Decodable, Hashable {
+    struct Roast: Decodable, Encodable, Hashable {
         var name: String?
     }
 
-    struct Tag: Decodable, Hashable {
+    struct Tag: Decodable, Encodable, Hashable {
         enum CodingKeys: String, CodingKey {
             case id = "_id"
             case name
@@ -57,7 +57,7 @@ struct ProductResponse: Hashable, Identifiable, Decodable {
         var name: String?
     }
 
-    struct TastingNote: Decodable, Hashable {
+    struct TastingNote: Decodable, Encodable, Hashable {
         enum CodingKeys: String, CodingKey {
             case id = "_id"
             case name
@@ -67,7 +67,7 @@ struct ProductResponse: Hashable, Identifiable, Decodable {
         var name: String?
     }
 
-    struct Variant: Decodable, Hashable {
+    struct Variant: Decodable, Encodable, Hashable {
         enum CodingKeys: String, CodingKey {
             case id = "_id"
             case size

--- a/Bottomless/Models/RecordsResponse.swift
+++ b/Bottomless/Models/RecordsResponse.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
-struct RecordsResultResponse: Decodable {
+public struct RecordsResultResponse: Encodable, Decodable {
     var data: [RecordsResponse?]
 }
 
-struct RecordsResponse: Hashable, Identifiable, Decodable {
+public struct RecordsResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id = "_id"
         case adjusted_weight
@@ -13,7 +13,7 @@ struct RecordsResponse: Hashable, Identifiable, Decodable {
         case timestamp
     }
 
-    var id: String
+    public var id: String
     var adjusted_weight: Double
     var battery_level: Int
     var base_id: String

--- a/Bottomless/Models/ScaleResponse.swift
+++ b/Bottomless/Models/ScaleResponse.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct ScaleResponse: Hashable, Identifiable, Decodable {
+public struct ScaleResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id = "scale_status"
         case scaleLastConnected = "scale_last_connected"
@@ -8,7 +8,7 @@ struct ScaleResponse: Hashable, Identifiable, Decodable {
         case scaleBatteryLevel = "scale_battery_level"
     }
 
-    var id: String?
+    public var id: String?
     var scaleLastConnected: String?
     var scaleLastWeight: Double?
     var scaleBatteryLevel: Double?

--- a/Bottomless/Models/UpNextResponse.swift
+++ b/Bottomless/Models/UpNextResponse.swift
@@ -1,10 +1,10 @@
-struct UpNextResponse: Hashable, Identifiable, Decodable {
+public struct UpNextResponse: Hashable, Identifiable, Encodable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id = "variant"
         case product
     }
 
-    struct Product: Decodable, Hashable {
+    struct Product: Encodable, Decodable, Hashable {
         var _id: String
         var origin: String
         var size: Int
@@ -21,6 +21,6 @@ struct UpNextResponse: Hashable, Identifiable, Decodable {
         var _id: String
     }
 
-    var id: String
+    public var id: String
     var product: Product
 }

--- a/Bottomless/View Models/AccountViewModel.swift
+++ b/Bottomless/View Models/AccountViewModel.swift
@@ -3,30 +3,14 @@ import SwiftUI
 
 final class AccountViewModel: ObservableObject {
     @Published private(set) var accountResponse: AccountResponse?
-
-    private var accountCancellable: Cancellable? {
-        didSet { oldValue?.cancel() }
-    }
-
-    deinit {
-        accountCancellable?.cancel()
-    }
+    private var publishers = [AnyCancellable]()
+    private let fetchProvider = Fetch()
 
     func fetch() {
-        let url = URL(string: Urls.api.me)!
-
-        var request = URLRequest(url: url)
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpMethod = "GET"
-
-        let publisher = URLSession.shared.dataTaskPublisher(for: request)
-
-        accountCancellable = publisher
-            .map { $0.data }
-            .decode(type: AccountResponse.self, decoder: JSONDecoder())
+        fetchProvider.getAccount()
             .map { $0 }
-            .replaceError(with: nil)
-            .receive(on: RunLoop.main)
-            .assign(to: \.accountResponse, on: self)
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { self.accountResponse = $0.value })
+            .store(in: &publishers)
     }
 }

--- a/Bottomless/View Models/Fetch/Fetch.swift
+++ b/Bottomless/View Models/Fetch/Fetch.swift
@@ -1,0 +1,109 @@
+//
+//  Fetch.swift
+//  Bottomless
+//
+//  Created by Drew Volz on 12/29/20.
+//  Copyright © 2020 Drew Volz. All rights reserved.
+//  https://bitbucket.org/mariwi/implement-swift-generic-api-using-codable-and-combine/
+//  https://www.vadimbulavin.com/modern-networking-in-swift-5-with-urlsession-combine-framework-and-codable/
+//
+
+import Combine
+import SwiftUI
+
+public extension Fetch {
+    // MARK: Orders
+
+    func getUpNext() -> FetchResponse.UpNext {
+        return call(Urls.api.my, method: .GET)
+    }
+
+    func getInTransition() -> FetchResponse.InTransition {
+        return call(Urls.api.inTransition, method: .GET)
+    }
+
+    func getPastOrders() -> FetchResponse.PastOrders {
+        return call(Urls.api.orders, method: .GET)
+    }
+
+    // MARK: Scale
+
+    func getScale() -> FetchResponse.Scale {
+        return call(Urls.api.scaleStatus, method: .GET)
+    }
+
+    func getRecords() -> FetchResponse.Records {
+        return call(Urls.api.records, method: .GET)
+    }
+
+    func getHeatmap() -> FetchResponse.Heatmap {
+        return call(Urls.api.cleanData, method: .GET)
+    }
+
+    // MARK: Credits & Referrals
+
+    func getCredits() -> FetchResponse.Credits {
+        return call(Urls.api.credits, method: .GET)
+    }
+
+    // MARK: Search
+
+    func getProducts() -> FetchResponse.Products {
+        return call(Urls.api.products, method: .GET)
+    }
+
+    // MARK: Settings
+
+    func getAccount() -> FetchResponse.Account {
+        return call(Urls.api.me, method: .GET)
+    }
+
+    func setAlertPreferences(settings: Data) -> FetchResponse.Account {
+        return call(Urls.api.alerts, method: .POST, body: settings)
+    }
+
+    func setOrderingStrategy(level: Data) -> FetchResponse.Account {
+        return call(Urls.api.orderingStrategy, method: .POST, body: level)
+    }
+
+    func setAccountPaused(status: Data) -> FetchResponse.Account {
+        return call(Urls.api.pauseAccount, method: .POST, body: status)
+    }
+}
+
+public class Fetch: FetchProvider, ObservableObject {
+    enum Method: String {
+        case GET
+        case POST
+    }
+
+    public init() {}
+
+    private func call<T: Codable>(_ url: String, method: Method, body: Data = Data(), cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy) -> AnyPublisher<Response<T>, Error> {
+        let urlRequest = request(for: url, method: method, body: body, cachePolicy: cachePolicy)
+
+        return URLSession.shared
+            .dataTaskPublisher(for: urlRequest)
+            .tryMap { result -> Response<T> in
+                let value = try JSONDecoder().decode(T.self, from: result.data)
+                return Response(value: value, response: result.response)
+            }
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+
+    private func request(for url: String, method: Method, body: Data, cachePolicy: URLRequest.CachePolicy) -> URLRequest {
+        guard let url = URL(string: url) else { preconditionFailure("Bad URL") }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.cachePolicy = cachePolicy
+
+        if !body.isEmpty {
+            request.httpBody = body
+        }
+
+        return request
+    }
+}

--- a/Bottomless/View Models/Fetch/FetchProvider.swift
+++ b/Bottomless/View Models/Fetch/FetchProvider.swift
@@ -1,0 +1,73 @@
+//
+//  FetchProvider.swift
+//  Bottomless
+//
+//  Created by Drew Volz on 12/29/20.
+//  Copyright © 2020 Drew Volz. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+public struct Response<T> {
+    let value: T
+    let response: URLResponse
+}
+
+public enum FetchResponse {
+    // MARK: Orders
+
+    public typealias UpNext = AnyPublisher<Response<UpNextResponse?>, Error>
+    public typealias InTransition = AnyPublisher<Response<InTransitionResultResponse?>, Error>
+    public typealias PastOrders = AnyPublisher<Response<OrdersResultResponse?>, Error>
+
+    // MARK: Scale
+
+    public typealias Scale = AnyPublisher<Response<ScaleResponse?>, Error>
+    public typealias Records = AnyPublisher<Response<RecordsResultResponse?>, Error>
+    public typealias Heatmap = AnyPublisher<Response<CleanDataResponse?>, Error>
+
+    // MARK: Credits & Referrals
+
+    public typealias Credits = AnyPublisher<Response<CreditsResponse?>, Error>
+
+    // MARK: Search
+
+    public typealias Products = AnyPublisher<Response<ProductResultResponse?>, Error>
+
+    // MARK: Settings
+
+    public typealias Account = AnyPublisher<Response<AccountResponse?>, Error>
+    public typealias AlertPreferences = AnyPublisher<Response<AccountResponse?>, Error>
+    public typealias OrderingStrategy = AnyPublisher<Response<AccountResponse?>, Error>
+    public typealias AccountPaused = AnyPublisher<Response<AccountResponse?>, Error>
+}
+
+public protocol FetchProvider {
+    // MARK: Orders
+
+    func getUpNext() -> FetchResponse.UpNext
+    func getInTransition() -> FetchResponse.InTransition
+    func getPastOrders() -> FetchResponse.PastOrders
+
+    // MARK: Scale
+
+    func getScale() -> FetchResponse.Scale
+    func getRecords() -> FetchResponse.Records
+    func getHeatmap() -> FetchResponse.Heatmap
+
+    // MARK: Credits & Referrals
+
+    func getCredits() -> FetchResponse.Credits
+
+    // MARK: Search
+
+    func getProducts() -> FetchResponse.Products
+
+    // MARK: Settings
+
+    func getAccount() -> FetchResponse.Account
+    func setAlertPreferences(settings: Data) -> FetchResponse.AlertPreferences
+    func setOrderingStrategy(level: Data) -> FetchResponse.OrderingStrategy
+    func setAccountPaused(status: Data) -> FetchResponse.AccountPaused
+}

--- a/Bottomless/View Models/OrdersViewModel.swift
+++ b/Bottomless/View Models/OrdersViewModel.swift
@@ -3,30 +3,16 @@ import SwiftUI
 
 final class OrdersViewModel: ObservableObject {
     @Published private(set) var ordersResponse: [OrdersResponse]? = []
-
-    private var ordersCancellable: Cancellable? {
-        didSet { oldValue?.cancel() }
-    }
-
-    deinit {
-        ordersCancellable?.cancel()
-    }
+    private var publishers = [AnyCancellable]()
+    private let fetchProvider = Fetch()
 
     func fetch() {
-        let url = URL(string: Urls.api.orders)!
-
-        var request = URLRequest(url: url)
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpMethod = "GET"
-
-        let publisher = URLSession.shared.dataTaskPublisher(for: request)
-
-        ordersCancellable = publisher
-            .map { $0.data }
-            .decode(type: OrdersResultResponse.self, decoder: JSONDecoder())
-            .map { $0.data as? [OrdersResponse] }
-            .replaceError(with: nil)
-            .receive(on: RunLoop.main)
-            .assign(to: \.ordersResponse, on: self)
+        fetchProvider.getPastOrders()
+            .map { $0 }
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: {
+                      self.ordersResponse = $0.value?.data as? [OrdersResponse]
+            })
+            .store(in: &publishers)
     }
 }

--- a/Bottomless/Views/LoggedInTabs/DataView/HeatmapView.swift
+++ b/Bottomless/Views/LoggedInTabs/DataView/HeatmapView.swift
@@ -38,7 +38,6 @@ var calendar: CalendarHeatmap = {
 
 var colorData: [String: UIColor] = [:]
 
-
 struct HeatmapView: UIViewRepresentable {
     @ObservedObject var cleanDataViewModel: CleanDataViewModel
 


### PR DESCRIPTION
John Sundell describes his use of protocols for networking [in the following way](https://swiftbysundell.com/articles/200-weeks-of-swift/#protocols-are-not-always-the-answer):

> * When we want to create an abstraction that involves a number of different requirements, such as when hiding certain concrete types in order to separate concerns.
> 
> * When sharing functionality between multiple types, just like how the standard library provides many different APIs through extensions on protocols like Collection, Equatable, and the Identifiable and RawRepresentable protocols that we used earlier.

He goes on to describe the drawbacks, too...

---

It feels a bit clunky at first, but it also feels like a step in the right direction. 

I feel that the networking is inching closer and closer to a reusable pattern. All the cruft that comes from mapping, sinking, and storing may eventually be co-located into a single method. I'd imaging it would take in generic type definitions. Again, that's an idea that I've been thinking about but haven't fleshed out yet.

We'll see where this goes!