### PR TITLE
Trigger the splitview sidebar to appear in the empty state

### DIFF
--- a/Bottomless.xcodeproj/project.pbxproj
+++ b/Bottomless.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		3A0458FE249E11BC00366F10 /* OrderingStrategyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0458FD249E11BC00366F10 /* OrderingStrategyView.swift */; };
 		3A045900249E13DE00366F10 /* OrderingStrategyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0458FF249E13DE00366F10 /* OrderingStrategyViewModel.swift */; };
 		3A1C332F24C20ACA00411A5E /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1C332E24C20ACA00411A5E /* App.swift */; };
+		3A22F5D125DCBD51002D4D21 /* UIKitShowSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22F5D025DCBD51002D4D21 /* UIKitShowSidebar.swift */; };
+		3A22F5D425DCBDBC002D4D21 /* NothingSelectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22F5D325DCBDBC002D4D21 /* NothingSelectedView.swift */; };
 		3A46478A24AD1CE500B9D4B5 /* ScaleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46478924AD1CE500B9D4B5 /* ScaleView.swift */; };
 		3A6A950424C13F410053DF8C /* ListModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6A950324C13F410053DF8C /* ListModifiers.swift */; };
 		3A6A97DA252E63240071DBB9 /* SwiftUICharts in Frameworks */ = {isa = PBXBuildFile; productRef = 3A6A97D9252E63240071DBB9 /* SwiftUICharts */; };
@@ -125,6 +127,8 @@
 		3A0458FF249E13DE00366F10 /* OrderingStrategyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingStrategyViewModel.swift; sourceTree = "<group>"; };
 		3A1C332E24C20ACA00411A5E /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		3A1C333624C20E9300411A5E /* info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = info.plist; path = ../info.plist; sourceTree = "<group>"; };
+		3A22F5D025DCBD51002D4D21 /* UIKitShowSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitShowSidebar.swift; sourceTree = "<group>"; };
+		3A22F5D325DCBDBC002D4D21 /* NothingSelectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NothingSelectedView.swift; sourceTree = "<group>"; };
 		3A46478924AD1CE500B9D4B5 /* ScaleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaleView.swift; sourceTree = "<group>"; };
 		3A6A950324C13F410053DF8C /* ListModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListModifiers.swift; sourceTree = "<group>"; };
 		3A6B6579259BF2FC00C2A499 /* Fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fetch.swift; sourceTree = "<group>"; };
@@ -505,6 +509,8 @@
 				3AF4FC6724C9150E00A61940 /* NavItems.swift */,
 				3AD926952491547E000AEFC8 /* LoggedInTabsView.swift */,
 				3AF4FC6524C8E65700A61940 /* LoggedInSidebar.swift */,
+				3A22F5D025DCBD51002D4D21 /* UIKitShowSidebar.swift */,
+				3A22F5D325DCBDBC002D4D21 /* NothingSelectedView.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -642,6 +648,7 @@
 				3AD926F124942C4A000AEFC8 /* OrdersView.swift in Sources */,
 				3AD926F324942D0B000AEFC8 /* DataView.swift in Sources */,
 				3AD927362498B954000AEFC8 /* ScaleViewModel.swift in Sources */,
+				3A22F5D125DCBD51002D4D21 /* UIKitShowSidebar.swift in Sources */,
 				3A0458DF2499862900366F10 /* DateHelpers.swift in Sources */,
 				3A0458F8249D5E7C00366F10 /* Binding.swift in Sources */,
 				3AF296BC249F69E7004BADE8 /* AlertsView.swift in Sources */,
@@ -683,6 +690,7 @@
 				3AD926E3249330F4000AEFC8 /* WelcomeView.swift in Sources */,
 				3AD926D6249311F1000AEFC8 /* URLs.swift in Sources */,
 				3AF296B4249E17E1004BADE8 /* ToggleSettingsPicker.swift in Sources */,
+				3A22F5D425DCBDBC002D4D21 /* NothingSelectedView.swift in Sources */,
 				3A0458D624996F2400366F10 /* AccountResponse.swift in Sources */,
 				3AD926FA24943500000AEFC8 /* InTransitionResponse.swift in Sources */,
 				3AD926DD24932998000AEFC8 /* FormValidation.swift in Sources */,

--- a/Bottomless/Views/LoggedInTabs/Navigation/NothingSelectedView.swift
+++ b/Bottomless/Views/LoggedInTabs/Navigation/NothingSelectedView.swift
@@ -1,0 +1,37 @@
+//
+//  NothingSelectedView.swift
+//  Bottomless
+//
+//  Created by Matthaus Woolard on 2/13/21.
+//  Modified by Drew Volz on 2/16/21
+//  https://lostmoa.com/blog/SummoningSplitViewSidebar
+//  Copyright © 2021 Drew Volz. All rights reserved.
+//
+
+import SwiftUI
+
+struct NothingSelectedView: View {
+    #if canImport(UIKit)
+        @State var onScreen: Bool = false
+    #endif
+
+    var body: some View {
+        Label("Nothing Selected", systemImage: "sparkles")
+
+        #if canImport(UIKit)
+            UIKitShowSidebar(onScreen: onScreen)
+                .frame(width: 0, height: 0)
+                .onAppear {
+                    onScreen = true
+                }.onDisappear {
+                    onScreen = false
+                }
+        #endif
+    }
+}
+
+struct NothingSelectedView_Previews: PreviewProvider {
+    static var previews: some View {
+        NothingSelectedView()
+    }
+}

--- a/Bottomless/Views/LoggedInTabs/Navigation/UIKitShowSidebar.swift
+++ b/Bottomless/Views/LoggedInTabs/Navigation/UIKitShowSidebar.swift
@@ -1,0 +1,49 @@
+//
+//  UIKitShowSidebar.swift
+//  Bottomless
+//
+//  Created by Matthaus Woolard on 2/13/21.
+//  Modified by Drew Volz on 2/16/21
+//  https://lostmoa.com/blog/SummoningSplitViewSidebar
+//  Copyright © 2021 Drew Volz. All rights reserved.
+//
+
+import SwiftUI
+
+struct UIKitShowSidebar: UIViewRepresentable {
+    let onScreen: Bool
+
+    func makeUIView(context _: Context) -> some UIView {
+        let uiView = UIView()
+
+        if onScreen {
+            DispatchQueue.main.async { [weak uiView] in
+                uiView?.next(
+                    of: UISplitViewController.self
+                )?.show(.primary)
+            }
+        }
+
+        return uiView
+    }
+
+    func updateUIView(_ uiView: UIViewType, context _: Context) {
+        DispatchQueue.main.async { [weak uiView] in
+            uiView?.next(
+                of: UISplitViewController.self
+            )?.show(.primary)
+        }
+    }
+}
+
+extension UIResponder {
+    func next<T>(of type: T.Type) -> T? {
+        guard let nextValue = self.next else {
+            return nil
+        }
+        guard let result = nextValue as? T else {
+            return nextValue.next(of: type.self)
+        }
+        return result
+    }
+}

--- a/Bottomless/Views/Root/RootView.swift
+++ b/Bottomless/Views/Root/RootView.swift
@@ -40,7 +40,10 @@ private extension RootView {
     @ViewBuilder func iPadNavigation() -> some View {
         NavigationView {
             iPadView()
-        }
+            NothingSelectedView()
+        }.navigationViewStyle(
+            DoubleColumnNavigationViewStyle()
+        )
     }
 
     @ViewBuilder func iPadView() -> some View {


### PR DESCRIPTION
Nifty bit of logic to present the splitview sidebar in the empty state which also allows for state restoration of the sidebar. 

Implementation taken from [here](https://lostmoa.com/blog/SummoningSplitViewSidebar/).