### PR TITLE
Add estimated delivery and fix battery percentage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,10 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Switch version of Xcode
-        run: sudo xcode-select --switch "/Applications/Xcode_12.app/Contents/Developer"
 
       - name: Build
         run: set -o pipefail && xcodebuild clean build -project Bottomless.xcodeproj -scheme Bottomless -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty --simple

--- a/Bottomless/Common/DateHelpers.swift
+++ b/Bottomless/Common/DateHelpers.swift
@@ -1,6 +1,28 @@
 import SwiftUI
 
-func formatAsRelativeTime(string: String) -> String {
+enum BottomlessDateFormatter: String {
+    case utc = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+    case gregorian = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+}
+
+func formatAsRelativeTime(string: String, fromFormatter: BottomlessDateFormatter = .gregorian) -> String {
+    guard string.count > 0 else { return "" }
+
+    let relativeFormatter = RelativeDateTimeFormatter()
+    relativeFormatter.unitsStyle = .full
+
+    let formatter = DateFormatter()
+    formatter.dateFormat = fromFormatter.rawValue
+
+    let someDateTime = formatter.date(from: string)
+    let relativeDate = relativeFormatter.localizedString(for: someDateTime ?? Date(), relativeTo: Date())
+
+    if relativeDate == "in 0 seconds" { return "…" }
+
+    return relativeDate
+}
+
+func formatAsEnglishRelativeTo(string: String) -> String {
     guard string.count > 0 else { return "" }
 
     let relativeFormatter = RelativeDateTimeFormatter()

--- a/Bottomless/Models/InTransitionResponse.swift
+++ b/Bottomless/Models/InTransitionResponse.swift
@@ -52,10 +52,12 @@ public struct InTransitionResponse: Hashable, Identifiable, Encodable, Decodable
         enum CodingKeys: String, CodingKey {
             case trackingDetails = "tracking_details"
             case publicUrl = "public_url"
+            case estimatedDeliveryDate = "est_delivery_date"
         }
 
         var trackingDetails: [TrackingDetail]?
         var publicUrl: String?
+        var estimatedDeliveryDate: String?
     }
 
     struct TrackingDetail: Encodable, Decodable, Hashable {

--- a/Bottomless/Views/LoggedInTabs/DataView/ScaleView.swift
+++ b/Bottomless/Views/LoggedInTabs/DataView/ScaleView.swift
@@ -22,7 +22,7 @@ struct ScaleView: View {
             return "..."
         }
 
-        return String(format: "%.0f", floor(level * 100)) + "%"
+        return String(format: "%.0f", level) + "%"
     }
 
     var status: String {

--- a/Bottomless/Views/LoggedInTabs/ProfileView/InProgressOrder.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/InProgressOrder.swift
@@ -11,6 +11,7 @@ struct InProgressOrder: View {
             }
         } else {
             InProgressOrderRow()
+            EstimatedDelivery()
         }
     }
 }
@@ -38,8 +39,24 @@ private extension InProgressOrder {
                         .font(.caption)
                         .lineLimit(1)
                         .foregroundColor(Color.gray)
+
+                    if shouldLink {
+                        EstimatedDelivery()
+                    }
                 }
             }
+        }
+    }
+
+    @ViewBuilder func EstimatedDelivery() -> some View {
+        if let deliveryDate = order.trackingUpdates?.first?.estimatedDeliveryDate {
+            HStack(spacing: 3) {
+                Text("Estimated to arrive")
+                Text(formatAsRelativeTime(string: deliveryDate, fromFormatter: .utc))
+                    .bold()
+            }
+            .font(.caption)
+            .foregroundColor(Color.gray)
         }
     }
 }

--- a/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
@@ -35,7 +35,6 @@ struct InTransitionDetailView: View {
     var body: some View {
         List {
             InProgressOrder(order: order, shouldLink: false)
-            EstimatedDelivery()
             Tracking()
         }
         .groupedStyle()
@@ -67,17 +66,6 @@ private extension InTransitionDetailView {
         if let url = order.trackingUpdates?.first?.publicUrl {
             Link("Open in browser…", destination: URL(string: url)!)
                 .font(.caption)
-        }
-    }
-
-    @ViewBuilder func EstimatedDelivery() -> some View {
-        if let deliveryDate = order.trackingUpdates?.first?.estimatedDeliveryDate {
-            HStack(spacing: 3) {
-                Text("Estimated to arrive")
-                Text(formatAsRelativeTime(string: deliveryDate, fromFormatter: .utc))
-                    .bold()
-            }
-            .font(.subheadline)
         }
     }
 }

--- a/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
@@ -35,6 +35,7 @@ struct InTransitionDetailView: View {
     var body: some View {
         List {
             InProgressOrder(order: order, shouldLink: false)
+            EstimatedDelivery()
             Tracking()
         }
         .groupedStyle()
@@ -66,6 +67,17 @@ private extension InTransitionDetailView {
         if let url = order.trackingUpdates?.first?.publicUrl {
             Link("Open in browser…", destination: URL(string: url)!)
                 .font(.caption)
+        }
+    }
+
+    @ViewBuilder func EstimatedDelivery() -> some View {
+        if let deliveryDate = order.trackingUpdates?.first?.estimatedDeliveryDate {
+            HStack(spacing: 3) {
+                Text("Estimated to arrive")
+                Text(formatAsRelativeTime(string: deliveryDate, fromFormatter: .utc))
+                    .bold()
+            }
+            .font(.subheadline)
         }
     }
 }


### PR DESCRIPTION
* Provides the estimated delivery date on both the list of orders and the in-progress detail view
* Removes the extra calculation around battery percentage