### PR TITLE
Allow city and state in tracking details to be optional

### DIFF
--- a/Bottomless/Models/InTransitionResponse.swift
+++ b/Bottomless/Models/InTransitionResponse.swift
@@ -73,8 +73,8 @@ public struct InTransitionResponse: Hashable, Identifiable, Encodable, Decodable
     }
 
     struct TrackingLocation: Encodable, Decodable, Hashable {
-        var city: String
-        var state: String
+        var city: String?
+        var state: String?
     }
 
     public var id: String

--- a/Bottomless/Models/OrdersResponse.swift
+++ b/Bottomless/Models/OrdersResponse.swift
@@ -57,8 +57,8 @@ public struct OrdersResponse: Hashable, Identifiable, Encodable, Decodable {
     }
 
     struct TrackingLocation: Encodable, Decodable, Hashable {
-        var city: String
-        var state: String
+        var city: String?
+        var state: String?
     }
 
     public var id: String

--- a/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
@@ -55,9 +55,14 @@ private extension InTransitionDetailView {
                             Text(item.message)
                                 .font(.caption)
                         }
+
                         Spacer()
-                        Text("\(item.trackingLocation?.city ?? ""), \(item.trackingLocation?.state ?? "")")
-                            .font(.caption)
+
+                        if let city = item.trackingLocation?.city,
+                            let state = item.trackingLocation?.state {
+                            Text("\(city), \(state)")
+                                .font(.caption)
+                        }
                     }
                 }
             }

--- a/Bottomless/Views/LoggedInTabs/ProfileView/OrderDetailView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/OrderDetailView.swift
@@ -55,9 +55,14 @@ private extension OrderDetailView {
                             Text(item.message)
                                 .font(.caption)
                         }
+
                         Spacer()
-                        Text("\(item.trackingLocation?.city ?? ""), \(item.trackingLocation?.state ?? "")")
-                            .font(.caption)
+
+                        if let city = item.trackingLocation?.city,
+                            let state = item.trackingLocation?.state {
+                            Text("\(city), \(state)")
+                                .font(.caption)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The viewmodel expected the city and state fields to always exist (and I would also expect them to always exist!) but it appears they are possibly undefined, breaking things. I've opted to display both only if all values are present.