### PR TITLE
Correctly sort in progress tracking updates

### DIFF
--- a/Bottomless/Common/DateHelpers.swift
+++ b/Bottomless/Common/DateHelpers.swift
@@ -100,20 +100,6 @@ func formatStringAsDate(dateString: String) -> Date? {
     return formatter.date(from: dateString)
 }
 
-func formatAsLongDate(dateString: String) -> String {
-    guard dateString.count > 0 else { return "" }
-
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-
-    let shortFormatter = DateFormatter()
-    shortFormatter.dateFormat = "MMMM dd, YYYY"
-
-    let firstDateTime = formatter.date(from: dateString) ?? Date()
-
-    return shortFormatter.string(from: firstDateTime)
-}
-
 func formatAsShortDateString(date: Date) -> String {
     let shortFormatter = DateFormatter()
     shortFormatter.dateFormat = "YYYY-MM-dd"
@@ -126,7 +112,7 @@ func formatAsReadableDateString(dateString: String) -> String {
     shortFormatter.dateFormat = "YYYY-MM-dd"
 
     let readableFormatter = DateFormatter()
-    readableFormatter.dateFormat = "MMMM dd, YYYY"
+    readableFormatter.dateFormat = "MMMM d, YYYY"
 
     let formattedDate = shortFormatter.date(from: dateString) ?? Date()
 

--- a/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
+++ b/Bottomless/Views/LoggedInTabs/ProfileView/InTransitionDetailView.swift
@@ -26,7 +26,7 @@ struct InTransitionDetailView: View {
 
     private func groupItems(items: TrackingItems) -> GroupedTracking {
         Dictionary(grouping: items, by: {
-            formatAsLongDate(dateString: $0.datetime)
+            formatStringAsShortDateString(dateString: $0.datetime)
         }).sorted { group1, group2 -> Bool in
             group1.key.compare(group2.key) == .orderedDescending
         }
@@ -44,7 +44,7 @@ struct InTransitionDetailView: View {
 private extension InTransitionDetailView {
     @ViewBuilder func Tracking() -> some View {
         ForEach(groupedItems ?? [], id: \.key) { day in
-            Section(header: Text(day.key)) {
+            Section(header: Text(formatAsReadableDateString(dateString: day.key))) {
                 ForEach(day.value.reversed(), id: \.self) { item in
                     HStack {
                         HStack {


### PR DESCRIPTION
* Follow-up to #51 where this was achieved for past orders
* Nix duplicate date formatting helper
* Drop the prepended zero on the human-readable date