### PR TITLE
Order preferences update

### DIFF
--- a/Bottomless/Models/AccountResponse.swift
+++ b/Bottomless/Models/AccountResponse.swift
@@ -20,6 +20,7 @@ public struct AccountResponse: Hashable, Identifiable, Encodable, Decodable {
         case orderingAggression = "ordering_aggression"
         case paused
         case pausedUntil
+        case phone
     }
 
     public var id: String?
@@ -39,20 +40,10 @@ public struct AccountResponse: Hashable, Identifiable, Encodable, Decodable {
     var orderingAggression: Int?
     var paused: Bool?
     var pausedUntil: String?
+    var phone: String?
 
     public struct AlertSettings: Codable, Hashable {
         var gifs: Bool?
-        var orderingSoon, outForDelivery, onTheWay, arrived: String?
-        var scaleNotifications: String?
-
-        enum CodingKeys: String, CodingKey {
-            case gifs
-            case orderingSoon = "ordering_soon"
-            case outForDelivery = "out_for_delivery"
-            case onTheWay = "on_the_way"
-            case arrived
-            case scaleNotifications = "scale_notifications"
-        }
     }
 
     struct Local: Decodable, Hashable, Encodable {

--- a/Bottomless/View Models/AlertsViewModel.swift
+++ b/Bottomless/View Models/AlertsViewModel.swift
@@ -6,10 +6,14 @@ final class AlertsViewModel: ObservableObject {
     private var publishers = [AnyCancellable]()
     private let fetchProvider = Fetch()
 
-    func post(settings: [String: Any]) {
-        let parameterDictionary = [
+    func post(settings: [String: Any], phone: String) {
+        var parameterDictionary: [String: Any] = [
             "alertSettings": settings,
         ]
+
+        if !phone.isEmpty {
+            parameterDictionary["phone"] = phone
+        }
 
         guard let httpBody = try? JSONSerialization.data(withJSONObject: parameterDictionary, options: []) else {
             return

--- a/Bottomless/Views/LoggedInTabs/Account/Preferences/AlertsView.swift
+++ b/Bottomless/Views/LoggedInTabs/Account/Preferences/AlertsView.swift
@@ -6,24 +6,10 @@ struct AlertsView: View {
     @ObservedObject var accountViewModel: AccountViewModel
     @ObservedObject var alertsViewModel = AlertsViewModel()
 
-    var contactOptions = ["text", "email", "none"]
-    var contactLabels = ["Text", "Email", "None"]
-
     var initialAlertSettings: [String: Any] { accountViewModel.accountResponse?.alertSettings.dictionary ?? Dictionary() }
 
     var gifs: Bool { accountViewModel.accountResponse?.alertSettings?.gifs ?? false }
-
-    var orderingSoon: String { accountViewModel.accountResponse?.alertSettings?.orderingSoon ?? "" }
-    var orderOnTheWay: String { accountViewModel.accountResponse?.alertSettings?.onTheWay ?? "" }
-    var outForDelivery: String { accountViewModel.accountResponse?.alertSettings?.outForDelivery ?? "" }
-    var orderArrived: String { accountViewModel.accountResponse?.alertSettings?.arrived ?? "" }
-    var scaleNotifications: String { accountViewModel.accountResponse?.alertSettings?.scaleNotifications ?? "" }
-
-    var orderingSoonIndex: Int { contactOptions.firstIndex(of: orderingSoon) ?? 0 }
-    var orderOnTheWayIndex: Int { contactOptions.firstIndex(of: orderOnTheWay) ?? 0 }
-    var outForDeliveryIndex: Int { contactOptions.firstIndex(of: outForDelivery) ?? 0 }
-    var orderArrivedIndex: Int { contactOptions.firstIndex(of: orderArrived) ?? 0 }
-    var scaleNotificationsIndex: Int { contactOptions.firstIndex(of: scaleNotifications) ?? 0 }
+    var phone: String { accountViewModel.accountResponse?.phone ?? "" }
 
     init(accountViewModel: AccountViewModel) {
         self.accountViewModel = accountViewModel
@@ -35,31 +21,6 @@ struct AlertsView: View {
             ToggleSettingsPicker(title: "Gif alerts",
                                  value: gifs,
                                  callback: onGifAlertsChange)
-
-            ListSettingsPicker(title: "Ordering soon",
-                               indexedValue: orderingSoonIndex,
-                               callback: onChangeOrderSoon,
-                               labels: contactLabels)
-
-            ListSettingsPicker(title: "Order on the way",
-                               indexedValue: orderOnTheWayIndex,
-                               callback: onChangeOrderOnTheWay,
-                               labels: contactLabels)
-
-            ListSettingsPicker(title: "Out for delivery",
-                               indexedValue: outForDeliveryIndex,
-                               callback: onChangeOutForDelivery,
-                               labels: contactLabels)
-
-            ListSettingsPicker(title: "Order arrived",
-                               indexedValue: orderArrivedIndex,
-                               callback: onChangeOrderArrived,
-                               labels: contactLabels)
-
-            ListSettingsPicker(title: "Scale notifications",
-                               indexedValue: scaleNotificationsIndex,
-                               callback: onChangeScaleNotifications,
-                               labels: contactLabels)
         }
         .font(.body)
     }
@@ -70,32 +31,12 @@ private extension AlertsView {
         updateSettings(key: "gifs", value: value)
     }
 
-    func onChangeOrderSoon(value: Int) {
-        updateSettings(key: "ordering_soon", value: contactOptions[value])
-    }
-
-    func onChangeOrderOnTheWay(value: Int) {
-        updateSettings(key: "on_the_way", value: contactOptions[value])
-    }
-
-    func onChangeOutForDelivery(value: Int) {
-        updateSettings(key: "out_for_delivery", value: contactOptions[value])
-    }
-
-    func onChangeOrderArrived(value: Int) {
-        updateSettings(key: "arrived", value: contactOptions[value])
-    }
-
-    func onChangeScaleNotifications(value: Int) {
-        updateSettings(key: "scale_notifications", value: contactOptions[value])
-    }
-
     private func updateSettings(key: String, value: Any) {
         // update our local copy
         alertSettings.updateValue(value, forKey: key)
 
         // update our remote copy
-        alertsViewModel.post(settings: alertSettings)
+        alertsViewModel.post(settings: alertSettings, phone: phone)
     }
 }
 

--- a/Bottomless/Views/LoggedInTabs/Account/Preferences/SettingsSegmentView.swift
+++ b/Bottomless/Views/LoggedInTabs/Account/Preferences/SettingsSegmentView.swift
@@ -16,7 +16,7 @@ struct SettingsSegmentView: View {
                     }
 
                     Section(header: Text("Alerts"),
-                            footer: Text("⚠️ There's a bug updating these toggles, leaving the view, and coming back. The state you see may not be correct.") + Text("\n\n") + Text("⚠️ There's a bug if you've not yet linked a phone number to your account, so this may not work if you select \"Text\".")) {
+                            footer: Text("⚠️ There's a bug updating these toggles, leaving the view, and coming back. The state you see may not be correct.")) {
                         AlertsView(accountViewModel: accountViewModel)
                     }
                 }


### PR DESCRIPTION
Looks like bottomless nixed the ability to customize the alerts for the
various stages of an order's progress. This leaves us with the ability
to flip only the "gifs enabled" switch.

This PR removes all the viewmodel and view building for the individual
order progress settings, the warning about not having added a phone
number, and updates the gif alerts setting based upon having a number
linked to your account or not to. This respects email or sms-based
account settings.